### PR TITLE
NO-TICK Reducing python version from 3.7.5 to 3.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,4 +29,4 @@ ecdsa = "*"
 casperlabs-client-test = {version="*", index="pypi-test"}
 
 [requires]
-python_version = "3.7.5"
+python_version = "3.7"


### PR DESCRIPTION
The specificity of python version in Pipfile is causing issues building CasperLabs/hack/docker on machines with Python 3.7 other than 3.7.5.