### PR TITLE
STS-79: Add logic to issue supervisord commands remotely on casper nodes

### DIFF
--- a/sh/scripts/node_systemctl.py
+++ b/sh/scripts/node_systemctl.py
@@ -1,0 +1,78 @@
+import argparse
+import subprocess
+
+from stests import chain
+from stests.core import crypto
+from stests.core.utils import args_validator
+from stests.core.utils import cli as utils
+from stests.core.utils import env
+from arg_utils import get_network_node
+from stests.core.types.infra import Node
+
+# CLI argument parser.
+ARGS = argparse.ArgumentParser("Displays an on-chain account balance.")
+
+# CLI argument: network name.
+ARGS.add_argument(
+    "--net",
+    default=env.get_network_name(),
+    dest="network",
+    help="Network name {type}{id}, e.g. nctl1.",
+    type=args_validator.validate_network,
+    )
+
+# CLI argument: node index.
+ARGS.add_argument(
+    "--node",
+    default=1,
+    dest="node",
+    help="Node index, e.g. 1.",
+    type=args_validator.validate_node_index
+    )
+
+# CLI argument: systemctl command.
+ARGS.add_argument(
+    "--command",
+    dest="command",
+    help="systemctl command to run on node, e.g. stop, start, restart.",
+    type=str,
+    choices=('restart', 'start', 'stop'),
+    )
+
+# CLI argument: SSH username.
+ARGS.add_argument(
+    "--ssh-user",
+    default='cladmin',
+    dest="ssh_user",
+    help="SSH username.",
+    type=str,
+    )
+
+def remote_node_systemctl(node: Node, ssh_user: str, command: str):
+    '''Issue a systemctl command to a remote casper-node instance. This is a
+    building block for being able to simulate bringing up/down a casper-node in
+    a long-running network.
+
+    This assumes that the given user's keys are installed on both this stests
+    control machine as well as on the remote machine to connect to. The given
+    user will also need to have sudo access on the remote machine.
+
+    :param node: The Node to run the command on.
+    :param ssh_user: The username to SSH into the remote machine as.
+    :param command: The `systemctl` command to run on the casper-node service.
+
+    :returns None
+    '''
+
+    args = (
+        'ssh',
+        f'{ssh_user}@{node.host}',
+        '-i', '~/aws-casperlabs-marklemoine.pem' # Just for testing
+        f'sudo systemctl {command} casper-node.service',
+    )
+
+    subprocess.run(args, check=True)
+
+# TODO: Just for testing, remove.
+if __name__ == '__main__':
+    pass

--- a/sh/scripts/node_systemctl.py
+++ b/sh/scripts/node_systemctl.py
@@ -7,8 +7,8 @@ from stests.core import crypto
 from stests.core.utils import args_validator
 from stests.core.utils import cli as utils
 from stests.core.utils import env
-from arg_utils import get_network_node
 from stests.core.types.infra import Node
+from arg_utils import get_network_node
 
 # CLI argument parser.
 ARGS = argparse.ArgumentParser("Executes a systemctl command to the casper-node service on a node.")
@@ -34,10 +34,11 @@ ARGS.add_argument(
 # CLI argument: systemctl command.
 ARGS.add_argument(
     "--command",
+    default='status',
     dest="command",
     help="systemctl command to run on node, e.g. stop, start, restart.",
     type=str,
-    choices=('restart', 'start', 'stop'),
+    choices=('restart', 'start', 'status', 'stop'),
     )
 
 # CLI argument: SSH username.
@@ -52,6 +53,7 @@ ARGS.add_argument(
 # CLI argument: SSH username.
 ARGS.add_argument(
     "--ssh-key-path",
+    default=None,
     dest="ssh_key_path",
     help="Path to SSH key.",
     type=Path,
@@ -63,7 +65,7 @@ def remote_node_systemctl(
     command: str,
     ssh_key_path: Path=None,
     check_rc: bool=False,
-    ) -> subprocess.CompletedProcess:
+    ):
     '''Issue a systemctl command to a remote casper-node instance. This is a
     building block for being able to simulate bringing up/down a casper-node in
     a long-running network.
@@ -94,18 +96,24 @@ def remote_node_systemctl(
 
     subprocess.run(yield_args(), check=check_rc)
 
-# TODO: Just for testing, remove.
-if __name__ == '__main__':
-    # test_node = Node(host='54.212.51.31')
+def main(args):
+    """Entry point.
 
-    # Quacks like a `Node` for now.
-    class TestNode:
-        def __init__(self, host):
-            self.host = host
+    :param args: Parsed CLI arguments.
+
+    """
+    utils.log(f"Executing `systemctl {args.command}`:")
+
+    _, node = get_network_node(args)
 
     remote_node_systemctl(
-        node=TestNode('54.212.51.31'),
-        ssh_user='cladmin',
-        command='status',
-        ssh_key_path=Path('/home/mark/aws-casperlabs-marklemoine.pem'),
+        node=node,
+        ssh_user=args.ssh_user,
+        command=args.command,
+        ssh_key_path=args.ssh_key_path,
+        check_rc=False,
     )
+
+# TODO: Just for testing, remove.
+if __name__ == '__main__':
+    main(ARGS.parse_args())

--- a/sh/utils/set_aliases.sh
+++ b/sh/utils/set_aliases.sh
@@ -16,10 +16,10 @@ function _exec_cmd()
 }
 
 # ###############################################################
-# ALIASES: Stack 
+# ALIASES: Stack
 # ###############################################################
 
-alias stests-stack-update=$STESTS_PATH_SH/stack/update.sh                                             
+alias stests-stack-update=$STESTS_PATH_SH/stack/update.sh
 alias stests-stack-vars=$STESTS_PATH_SH/stack/view_vars.sh
 
 # ###############################################################
@@ -27,8 +27,8 @@ alias stests-stack-vars=$STESTS_PATH_SH/stack/view_vars.sh
 # ###############################################################
 
 alias stests-interactive='$STESTS_PATH_SH/workers/interactive.sh unified'
-alias stests-interactive-monitoring='$STESTS_PATH_SH/workers/interactive.sh monitoring'               
-alias stests-interactive-orchestration='$STESTS_PATH_SH/workers/interactive.sh orchestration'         
+alias stests-interactive-monitoring='$STESTS_PATH_SH/workers/interactive.sh monitoring'
+alias stests-interactive-orchestration='$STESTS_PATH_SH/workers/interactive.sh orchestration'
 
 # ###############################################################
 # ALIASES: Workers
@@ -40,6 +40,12 @@ alias stests-workers-restart=$STESTS_PATH_SH/workers/restart.sh
 alias stests-workers-start=$STESTS_PATH_SH/workers/start.sh
 alias stests-workers-status=$STESTS_PATH_SH/workers/status.sh
 alias stests-workers-stop=$STESTS_PATH_SH/workers/stop.sh
+
+# ###############################################################
+# ALIASES: Nodes
+# ###############################################################
+
+alias stests-node-systemctl='_exec_cmd $STESTS_PATH_SH_SCRIPTS/node_systemctl.py'
 
 # ###############################################################
 # ALIASES: Registration


### PR DESCRIPTION
This is a new command + alias to allow for issuing systemctl commands (e.g. start/stop/restart/etc.) to the actual nodes within an stests cluster. Similar to how one would use `nctl-stop`/`nctl-start`/etc to manage the services on an `nctl` backed stests network, this would allow for node control in an "LRT" environment.